### PR TITLE
Update zuul pipeline to use the new version trigger build job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -9,7 +9,9 @@
       jobs:
         - "trigger-build":
             vars:
-              webhook_url: "https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/build-watcher"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "build-watcher"
     kebechet-auto-gate:
       jobs:
         - "thoth-coala"

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -80,3 +80,7 @@ objects:
       triggers:
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret


### PR DESCRIPTION
Add generic trigger to buildconfig for incoming generic webhook.
The `generic-webhook-secret` secret is a prerequisite for using this new build config.
Update the zuul config to use the new trigger build job API in zuul-config.