### PR TITLE
Prometheus metrics integration for build-watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# ansible
+*.retry

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from multiprocessing import Manager
 
 import click
 
-from thamos.lib import image_analysis
+from thamos.lib import build_analysis
 from thamos.config import config as configuration
 from thoth.common import init_logging
 from thoth.common import OpenShift
@@ -40,6 +40,11 @@ _LOGGER = logging.getLogger("thoth.build_watcher")
 
 _HERE_DIR = os.path.dirname(os.path.abspath(__file__))
 _SKOPEO_EXEC_PATH = os.getenv("SKOPEO_EXEC_PATH", os.path.join(_HERE_DIR, "bin", "skopeo"))
+
+
+def _buildlog_metadata(api_endpoint: str, build_log: str):
+    """Gather metadata for the build log."""
+    return {"apiversion": api_endpoint, "kind": "BuildLog", "log": build_log, "metadata": "string"}
 
 
 def _existing_producer(queue: Queue, build_watcher_namespace: str):
@@ -57,29 +62,63 @@ def _existing_producer(queue: Queue, build_watcher_namespace: str):
     _LOGGER.info("Queuing existing images for analyses has finished, all of them were scheduled for analysis")
 
 
+def _get_build(openshift, strategy: dict, build_reference: dict, event_metadata: dict) -> dict:
+    """Gather Build log and Base Image based upon the strategy of the build."""
+    if strategy.get("sourceStrategy"):
+        build_reference["base_input_reference"] = strategy.get("sourceStrategy", {}).get("from", {}).get("name", "")
+    elif strategy.get("dockerStrategy") and strategy.get("dockerStrategy", {}).get("from", {}):
+        build_reference["base_input_reference"] = strategy.get("dockerStrategy", {}).get("from", {}).get("name", "")
+    else:
+        build_reference["base_input_reference"] = ""
+    try:
+        build_log = openshift.get_build_log(
+            build_id=event_metadata.get("name"), namespace=event_metadata.get("namespace")
+        )
+    except Exception as exc:
+        _LOGGER.exception("Failed to get the log for build %s: %s", event_metadata.get("name"), str(exc))
+        build_log = ""
+    build_reference["build_log_reference"] = _buildlog_metadata(event_metadata.get("selfLink"), build_log)
+
+    return build_reference
+
+
 def _event_producer(queue: Queue, build_watcher_namespace: str):
     """Accept events from the cluster and queue them into work queue processed by the main process."""
     _LOGGER.info("Starting event producer")
     openshift = OpenShift()
     v1_build = openshift.ocp_client.resources.get(api_version="v1", kind="Build")
     for event in v1_build.watch(namespace=build_watcher_namespace):
+        event_name = event["object"].metadata.name
+        build_reference = {"build_log_reference": None, "base_input_reference": None, "output_reference": None}
         if event["object"].status.phase != "Complete":
             _LOGGER.debug(
-                "Ignoring build event for %r - not completed phase %r",
-                event["object"].metadata.name,
+                "Ignoring build event for %r - not completed phase %r", event_name, event["object"].status.phase
+            )
+            continue
+        elif event["object"].status.phase == "Failed":
+            _LOGGER.debug(
+                "Submitting base_image and build_log as build event for %r - the phase is %r",
+                event_name,
                 event["object"].status.phase,
             )
+            strategy = event["object"].spec.strategy
+            build_reference = _get_build(openshift, strategy, build_reference, event["object"].metadata)
+            _LOGGER.info("Queueing build log based on build event %r for further processing", event_name)
+            queue.put(build_reference)
             continue
 
         _LOGGER.debug("New build event: %s", str(event))
-        event_name = event["object"].metadata.name
-        output_reference = event["object"].status.outputDockerImageReference
-        _LOGGER.info("Queueing %r based on build event %r for further processing", output_reference, event_name)
-        queue.put(output_reference)
+        build_reference["output_reference"] = event["object"].status.outputDockerImageReference
+        strategy = event["object"].spec.strategy
+        build_reference = _get_build(openshift, strategy, build_reference, event["object"].metadata)
+        _LOGGER.info("Queueing build log based on build event %r for further processing", event_name)
+        queue.put(build_reference)
 
 
-def _do_analyze_image(
+def _do_analyze_build(
     output_reference: str,
+    build_log_reference: str,
+    base_input_reference: str,
     push_registry: str = None,
     *,
     environment_type: str = None,
@@ -89,7 +128,7 @@ def _do_analyze_image(
     dst_registry_password: str = None,
     src_verify_tls: bool = True,
     dst_verify_tls: bool = True,
-) -> str:
+):
     if push_registry:
         _LOGGER.info("Pushing image %r to an external push registry %r", output_reference, push_registry)
         output_reference = _push_image(
@@ -104,18 +143,26 @@ def _do_analyze_image(
         )
         _LOGGER.info("Successfully pushed image to %r", output_reference)
 
-    analysis_id = image_analysis(
-        image=output_reference,
+    build_detail = {"base_image": base_input_reference, "output_image": output_reference}
+    build_detail.update(build_log_reference)
+
+    analysis_ids = build_analysis(
+        build_detail=build_detail,
         environment_type=environment_type,
         registry_user=dst_registry_user,
         registry_password=dst_registry_password,
-        verify_tls=dst_verify_tls,
+        registry_verify_tls=dst_verify_tls,
         nowait=True,
     )
 
-    _LOGGER.info("Successfully submitted %r to Thoth for analysis; analysis id: %s", output_reference, analysis_id)
+    _LOGGER.info(
+        "Successfully submitted %s,%s,%s to Thoth for analysis",
+        output_reference,
+        base_input_reference,
+        build_log_reference,
+    )
 
-    return analysis_id
+    return
 
 
 def _push_image(
@@ -179,12 +226,22 @@ def _submitter(
 ) -> None:
     """Read messages from queue and submit each message with image to Thoth for analysis."""
     while True:
-        output_reference = queue.get()
-        _LOGGER.info("Handling analysis of image %r", output_reference)
+        reference = queue.get()
+        if isinstance(reference, dict):
+            build_log_reference = reference.get("build_log_reference", None)
+            base_input_reference = reference.get("base_input_reference", None)
+            output_reference = reference.get("output_reference", None)
+        else:
+            output_reference = reference
+            build_log_reference = ""
+            base_input_reference = ""
+        _LOGGER.info("Handling analysis of image %r", reference)
 
         try:
-            _do_analyze_image(
+            _do_analyze_build(
                 output_reference,
+                build_log_reference,
+                base_input_reference,
                 push_registry,
                 environment_type=environment_type,
                 src_registry_user=src_registry_user,
@@ -350,7 +407,7 @@ def cli(
     if pass_token:
         if src_registry_password:
             raise ValueError("Flag --pass-token is disjoint with explicit source password propagation")
-
+        src_registry_user = "build-watcher"
         src_registry_password = openshift.token
 
         if not push_registry and (not dst_registry_user and not dst_registry_password):
@@ -358,6 +415,7 @@ def cli(
             dst_registry_user, dst_registry_password = src_registry_user, src_registry_password
         elif not dst_registry_user and not dst_registry_password:
             # Reuse credentials if we are in the cluster.
+            dst_registry_user = "build-watcher"
             dst_registry_password = openshift.token
 
     producer = Process(target=_event_producer, args=(queue, build_watcher_namespace))
@@ -378,7 +436,8 @@ def cli(
     process_pool = []
     _LOGGER.info(
         "Starting worker processes, number of workers is set to: %d, environment type of images submitted is %s",
-        workers_count, environment_type
+        workers_count,
+        environment_type,
     )
     for worker in range(workers_count):
         p = Process(target=_submitter, args=args)

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -194,26 +194,22 @@ objects:
                 # Set to a non-zero value to suppres annoying TLS warnings by Thamos lib:
                 - name: THAMOS_DISABLE_TLS_WARNING
                   value: "${THAMOS_DISABLE_TLS_WARNING}"
-                # - name: PROMETHEUS_PUSHGATEWAY_HOST
-                #   valueFrom:
-                #     configMapKeyRef:
-                #       key: prometheus-pushgateway-host
-                #       name: thoth
-                # - name: PROMETHEUS_PUSHGATEWAY_PORT
-                #   valueFrom:
-                #     configMapKeyRef:
-                #       name: thoth
-                #       key: prometheus-pushgateway-port
+                - name: PROMETHEUS_PUSHGATEWAY_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: prometheus-pushgateway-host
+                      name: thoth
+                - name: PROMETHEUS_PUSHGATEWAY_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: prometheus-pushgateway-port
                 - name: SENTRY_DSN
                   valueFrom:
                     secretKeyRef:
                       name: thoth
                       key: sentry-dsn
 
-                - name: PROMETHEUS_PUSHGATEWAY_HOST
-                  value: "${PROMETHEUS_PUSHGATEWAY_HOST}"
-                - name: PROMETHEUS_PUSHGATEWAY_PORT
-                  value: "${PROMETHEUS_PUSHGATEWAY_PORT}"
               resources:
                 requests:
                   memory: "384Mi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-py36 = true
+target-version = ['py36']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
Depends-On: #44 
Prometheus metrics are added to build-watcher. 
Metrics:
- No of images submitted for analysis.
- No of build logs submitted for analysis.
- No of builds failed.
- No of images pushed to the external registry.

 Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>