### PR TITLE
thoth configmap required for build-watcher

### DIFF
--- a/openshift/configmap-template.yaml
+++ b/openshift/configmap-template.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-watcher-configmap
+  annotations:
+    description: This is Thoth - Build Watcher
+    openshift.io/display-name: Thoth Core Configmap
+    version: 0.1.0
+    tags: thoth,ai-stacks,aistacks
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to deploy Thoth Core Services to OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+  labels:
+    app: thoth
+    template: build-watcher-configmap
+    component: build-watcher
+
+objects:
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: thoth
+      labels:
+        app: thoth
+        component: configmap
+    data:
+      storage-bucket-name: ${THOTH_DEPLOYMENT_NAME}
+      prometheus-pushgateway-host: ${PROMETHEUS_PUSHGATEWAY_HOST}
+      prometheus-pushgateway-port: ${PROMETHEUS_PUSHGATEWAY_PORT}
+      sentry-dsn: ${SENTRY_DSN}
+
+parameters:
+  - description: Storage bucket name to use for persisted files
+    displayName: Thoth Storage bucket name
+    required: true
+    value: thoth-test
+    name: THOTH_DEPLOYMENT_NAME
+
+  - displayName: PROMETHEUS_PUSHGATEWAY_HOST
+    description: A host to push prometheus metrics via pushgateway.
+    name: PROMETHEUS_PUSHGATEWAY_HOST
+    required: false
+    value: "pushgateway"
+
+  - displayName: PROMETHEUS_PUSHGATEWAY_PORT
+    description: A port to send prometheus metrics via pushgateway.
+    name: PROMETHEUS_PUSHGATEWAY_PORT
+    required: false
+    value: "80"
+
+  - displayName: SENTRY_DSN
+    description: A DSN to a Sentry instance to log to.
+    name: SENTRY_DSN
+    required: false

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -220,7 +220,7 @@ objects:
                       key: prometheus-pushgateway-port
                 - name: SENTRY_DSN
                   valueFrom:
-                    secretKeyRef:
+                    configMapKeyRef:
                       name: thoth
                       key: sentry-dsn
                 - name: THOTH_DEPLOYMENT_NAME


### PR DESCRIPTION
thoth configmap required for build-watcher
- As this module will be used in a different namespaces which might not be managed by thoth, it would be useful in creating thoth configmap while deploying build-watcher.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>