### PR TITLE
sa and rolebinding creation separated

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -101,51 +101,12 @@ parameters:
     displayName: Pass token from service account
     value: "0"
 
-  - name: PROMETHEUS_PUSHGATEWAY_HOST
-    description: Prometheus push gateway host to send metrics to.
-    displayName: Prometheus push gateway host
-    required: false
-
-  - name: PROMETHEUS_PUSHGATEWAY_PORT
-    description: Prometheus push gateway port to send metrics to.
-    displayName: Prometheus push gateway port
-    required: false
-
   - name: THOTH_INFRA_NAMESPACE
     description: Namespace on which Build Watcher image is build.
     displayName: Thoth infra namespace
     required: true
 
 objects:
-  - kind: RoleBinding
-    apiVersion: v1
-    metadata:
-      annotations:
-        thoth-station.ninja/template-version: 0.1.0
-      name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
-      labels:
-        app: thoth
-        component: build-watcher
-    roleRef:
-      kind: ClusterRole
-      name: edit
-    subjects:
-      - kind: ServiceAccount
-        name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
-        namespace: "${THOTH_WATCHED_NAMESPACE}"
-
-  - kind: ServiceAccount
-    apiVersion: v1
-    metadata:
-      annotations:
-        thoth-station.ninja/template-version: 0.1.0
-      name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
-      namespace: "${THOTH_WATCHED_NAMESPACE}"
-      labels:
-        app: thoth
-        component: build-watcher
-    automountServiceAccountToken: true
-
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:

--- a/openshift/service-account-template.yaml
+++ b/openshift/service-account-template.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-watcher-sa
+  annotations:
+    description: This is Thoth - Build Watcher
+    openshift.io/display-name: 'Thoth Core: Build Watcher'
+    version: 0.1.0
+    tags: poc,thoth,build-watcher,ai-stacks,aistacks
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to deploy Thoth Build
+      Watcher on OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    thoth-station.ninja/template-version: 0.1.0
+  labels:
+    template: build-watcher-sa
+    app: thoth
+    component: build-watcher
+
+parameters:
+  - description: Namespace on which Build Watcher should listen to builds.
+    displayName: Build Watcher namespace
+    required: true
+    name: THOTH_WATCHED_NAMESPACE
+
+objects:
+  - kind: RoleBinding
+    apiVersion: v1
+    metadata:
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
+      labels:
+        app: thoth
+        component: build-watcher
+    roleRef:
+      kind: ClusterRole
+      name: edit
+    subjects:
+      - kind: ServiceAccount
+        name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
+        namespace: "${THOTH_WATCHED_NAMESPACE}"
+
+  - kind: ServiceAccount
+    apiVersion: v1
+    metadata:
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      name: "build-watcher-${THOTH_WATCHED_NAMESPACE}"
+      namespace: "${THOTH_WATCHED_NAMESPACE}"
+      labels:
+        app: thoth
+        component: build-watcher
+    automountServiceAccountToken: true

--- a/playbooks/build-watcher/tasks/main.yaml
+++ b/playbooks/build-watcher/tasks/main.yaml
@@ -8,11 +8,24 @@
   register: project_exists
   ignore_errors: true
 
+- name: "check if ImageStream exists"
+  command: "oc get imagestream --namespace {{ THOTH_INFRA_NAMESPACE }} build-watcher"
+  register: imagestream_exists
+  ignore_errors: true
+  changed_when: false
+
 - name: "importing required build-watcher ImageStream from upstream registries"
   shell: >
-    oc tag --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }}
+    oc tag --namespace {{ THOTH_INFRA_NAMESPACE }}
     quay.io/thoth-station/build-watcher:v0.6.0-dev build-watcher:latest
+  when: imagestream_exists is failed
   ignore_errors: true
+
+- name: "check if required ConfigMap exists"
+  command: "oc get configmap --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }} thoth"
+  register: configmap_exists
+  ignore_errors: true
+  changed_when: false
 
 - name: "creating Thoth ConfigMap"
   shell: >
@@ -22,6 +35,20 @@
     -p "PROMETHEUS_PUSHGATEWAY_PORT={{ PROMETHEUS_PUSHGATEWAY_PORT }}"
     -p "SENTRY_DSN={{ SENTRY_DSN }}"
     | oc apply --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }} -f -
+  when: configmap_exists is failed
+
+- name: "check if required ServiceAccount exists"
+  command: "oc get sa --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }} build-watcher-{{THOTH_WATCHED_NAMESPACE}}"
+  register: sa_exists
+  ignore_errors: true
+  changed_when: false
+
+- name: "creating build watcher ServiceAccount and RoleBinding"
+  shell: >
+    oc process --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }}  --filename ../openshift/service-account-template.yaml
+    -p "THOTH_WATCHED_NAMESPACE={{ THOTH_WATCHED_NAMESPACE }}"
+    | oc apply --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }} -f -
+  when: sa_exists is failed
 
 - name: create DeploymentConfig
   shell: >
@@ -42,6 +69,4 @@
     -p "THOTH_SRC_REGISTRY_PASSWORD={{ THOTH_SRC_REGISTRY_PASSWORD }}"
     -p "THOTH_DST_REGISTRY_USER={{ THOTH_DST_REGISTRY_USER }}"
     -p "THOTH_DST_REGISTRY_PASSWORD={{ THOTH_DST_REGISTRY_PASSWORD }}"
-    -p "PROMETHEUS_PUSHGATEWAY_HOST={{ PROMETHEUS_PUSHGATEWAY_HOST }}"
-    -p "PROMETHEUS_PUSHGATEWAY_PORT={{ PROMETHEUS_PUSHGATEWAY_PORT }}"
     | oc apply --namespace {{ THOTH_BUILD_WATCHER_NAMESPACE }} -f -


### PR DESCRIPTION
sa and rolebinding creation separated, as this module is designed to be deployed in external clusters as well where we might not get `ADMIN` roles, so creating roles for sa would have to requested to the admin. Hence having sa and rolebinding creation with deployment may not be the best way.

Explicit checking of configmap and imagestream, so that already present info is not changed.

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>