### PR TITLE
Push base image to external registry too

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ def _do_analyze_build(
     dst_verify_tls: bool = True,
 ) -> None:
     if push_registry:
-        _LOGGER.info("Pushing image %r to an external push registry %r", output_reference, push_registry)
+        _LOGGER.info("Pushing output image %r to an external push registry %r", output_reference, push_registry)
         output_reference = _push_image(
             output_reference,
             push_registry,
@@ -177,7 +177,22 @@ def _do_analyze_build(
             dst_verify_tls=dst_verify_tls,
         )
         _METRIC_IMAGES_PUSHED_REGISTRY.inc()
-        _LOGGER.info("Successfully pushed image to %r", output_reference)
+        _LOGGER.info("Successfully pushed output image to %r", output_reference)
+
+        if base_input_reference:
+            _LOGGER.info("Pushing base image %r to an external push registry %r", base_input_reference, push_registry)
+            base_input_reference = _push_image(
+                base_input_reference,
+                push_registry,
+                src_registry_user,
+                src_registry_password,
+                dst_registry_user,
+                dst_registry_password,
+                src_verify_tls=src_verify_tls,
+                dst_verify_tls=dst_verify_tls,
+            )
+            _METRIC_IMAGES_PUSHED_REGISTRY.inc()
+            _LOGGER.info("Successfully pushed base image to %r", base_input_reference)
 
     analysis_response = build_analysis(
         base_image=base_input_reference,


### PR DESCRIPTION
Push base image to external registry too
- As images can be built with some base image which was also built in the same repo, it might be useful to push them to the external registry and send them for build-analysis, this is one scenario to look at this. 
- another if the base image is in a different namespace, which can be accessed by the image being built, then also we would have to push the base image to external registry to allow user-API to analyze it.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>