### PR TITLE
 Fixing @ issue in image push to quay

### DIFF
--- a/app.py
+++ b/app.py
@@ -267,6 +267,8 @@ def _push_image(
 
     image_name = image.rsplit("/", maxsplit=1)[1]
     if "quay.io" in push_registry:
+        if "sha256" in image_name:
+            image_name = image_name.replace("@sha256", "")
         output = f"{push_registry}:{image_name.replace(':','-')}"
     else:
         output = f"{push_registry}/{image_name}"


### PR DESCRIPTION
Fixing @ issue in image push to quay

```
Pushing base image 'docker-registry.default.svc:5000/dh-prod-jupyterhub/python-36-ubi7@sha256:d608d5fab85badccb41b7307a3e78347b5fb4fe647e3897404df8f1b077028cf' to an external push registry 'quay.io/thoth-station/image-store'

Invalid destination name docker://quay.io/thoth-station/image-store:python-36-ubi7@sha256-d608d5fab85badccb41b7307a3e78347b5fb4fe647e3897404df8f1b077028cf: invalid reference format
```
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>