### PR TITLE
Use s2i-thoth-ubi-8-py38 as a base image

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -80,7 +80,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: s2i-thoth-ubi8-py36:latest
+            name: s2i-thoth-ubi8-py38:latest
           env:
             - name: ENABLE_PIPENV
               value: '1'


### PR DESCRIPTION
Fixes the following error during build:

```
---------------------------------- Pipfile.lock ----------------------------------
Running Python version 3.6, but Pipfile.lock requires Python version 3.8
subprocess exited with status 3
subprocess exited with status 3
error: build error: error building at STEP "RUN /usr/libexec/s2i/assemble": exit status 3
```